### PR TITLE
Fix: Import psutil in encode_server.py

### DIFF
--- a/ffmpeg-easy-distributed/ffmpeg-server/server/encode_server.py
+++ b/ffmpeg-easy-distributed/ffmpeg-server/server/encode_server.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 from typing import Dict, Set, Optional, List
 from pathlib import Path
+import psutil
 import time
 
 from shared.protocol import Message, MessageType, send_message, receive_message, ProtocolError


### PR DESCRIPTION
Resolves NameError: name 'psutil' is not defined by adding the missing import for the psutil library. The library is listed in requirements.txt but was not imported in the server code.