### PR TITLE
Fix: Add ufw to Ubuntu installer and resolve Settings.data AttributeE…

### DIFF
--- a/ffmpeg-easy-distributed/ffmpeg-gui/gui/main_window.py
+++ b/ffmpeg-easy-distributed/ffmpeg-gui/gui/main_window.py
@@ -848,7 +848,7 @@ class MainWindow:
 
     def _enqueue_paths(self, paths: list[Path]):
         out_root = Path(self.output_folder.get()) if self.output_folder.get() and not self.output_folder.get().startswith("(no") else None
-        keep_structure = Settings.data.get("keep_folder_structure", True)
+        keep_structure = self.settings.data.get("keep_folder_structure", True)
         input_folder = self.input_folder.get()
         
         current_batch_job_ids = []

--- a/ffmpeg-easy-distributed/ffmpeg-server/install_ubuntu.sh
+++ b/ffmpeg-easy-distributed/ffmpeg-server/install_ubuntu.sh
@@ -93,7 +93,8 @@ install_dependencies() {
         apt-transport-https \
         ca-certificates \
         gnupg \
-        lsb-release
+        lsb-release \
+        ufw
     
     # Installation de Python 3.12 si nécessaire
     if ! command -v python3.12 &> /dev/null; then


### PR DESCRIPTION
…rror in GUI

- Modified `ffmpeg-easy-distributed/ffmpeg-server/install_ubuntu.sh` to include `ufw` in the list of essential packages to be installed.
- Fixed an `AttributeError` in `ffmpeg-easy-distributed/ffmpeg-gui/gui/main_window.py` where `Settings.data` was being accessed as a class attribute instead of an instance attribute (`self.settings.data`) in the `_enqueue_paths` method. This resolves an error occurring during folder import on macOS.