### PR TITLE
Fix: Remove unexpected 'loop' argument from DistributedClient constru…

### DIFF
--- a/ffmpeg-easy-distributed/ffmpeg-gui/main.py
+++ b/ffmpeg-easy-distributed/ffmpeg-gui/main.py
@@ -39,7 +39,7 @@ def main():
     asyncio.set_event_loop(loop)
 
     # Initialisation des composants distribués
-    distributed_client = DistributedClient(settings, loop=loop) # Pass loop if needed by client
+    distributed_client = DistributedClient(settings) # loop is implicitly used by asyncio
     server_discovery = ServerDiscovery(distributed_client, settings, loop=loop)
     capability_matcher = CapabilityMatcher()
     job_scheduler = JobScheduler(distributed_client, capability_matcher, loop=loop)


### PR DESCRIPTION
…ctor

The DistributedClient class constructor in core/distributed_client.py does not accept a 'loop' argument. The asyncio event loop is implicitly used by asincio functions called within the class. This change removes the unnecessary and problematic 'loop' argument from its instantiation in main.py, resolving the TypeError on startup.