### PR TITLE
Fix: Correct media type logging and implement adaptive UI for encodin…

### DIFF
--- a/ffmpeg-easy-distributed/ffmpeg-gui/gui/main_window.py
+++ b/ffmpeg-easy-distributed/ffmpeg-gui/gui/main_window.py
@@ -720,10 +720,13 @@ class MainWindow:
         
         # Séquence d'initialisation dans le bon ordre
         self._update_media_type_ui(initial_media_type)
-        self._update_codec_choices()           # Remplir les codecs selon le type de média
-        self._update_encoder_choices()         # Remplir les encodeurs selon le codec
-        self._update_container_choices()       # Remplir les conteneurs selon codec/encodeur
-        self._update_quality_controls_for_global()  # Adapter les contrôles qualité
+        self._update_codec_choices()           # Remplir les codecs selon le type de média (initial call)
+        self._update_encoder_choices()         # Remplir les encodeurs selon le codec (initial call)
+        self._update_container_choices()       # Remplir les conteneurs selon codec/encodeur (initial call)
+        # self._update_quality_controls_for_global() # This is the old call, it's now handled by
+                                                 # _initial_ui_setup via _update_ui_for_media_type_and_settings
+                                                 # which calls _update_quality_controls_ui.
+                                                 # The calls above ensure comboboxes have initial values before full orchestration.
         
         self.root.after(100, self._update_scroll_state)
         


### PR DESCRIPTION
…g settings

- Resolved incorrect logging of global media type changes when adding files. The log now only appears for explicit user changes to the global media type.
- Refactored UI update logic to be context-aware:
  - When a specific job is selected for configuration, the settings panel adapts to that job's media type and loads its specific settings.
  - When no job is selected, or the global media type dropdown is changed, the UI reflects global default settings for the chosen media type.
- Enhanced quality control UI elements to be more specific for video, audio, and image types, with appropriate labels and default values.
- Ensured that changes to UI settings in a job-specific context do not overwrite global default settings in AppState.
- New jobs correctly inherit from user-configurable global defaults.
- Fixed AttributeError by removing a redundant call to the old `_update_quality_controls_for_global` method during UI build; initialization is now correctly handled by `_initial_ui_setup` using the new orchestrator.