### PR TITLE
Fix: Improve audio encoder population robustness

### DIFF
--- a/ffmpeg-easy-distributed/ffmpeg-gui/core/ffmpeg_helpers.py
+++ b/ffmpeg-easy-distributed/ffmpeg-gui/core/ffmpeg_helpers.py
@@ -35,7 +35,7 @@ class FFmpegHelpers:
                             elif "jpegxl" in encoder_name or "jxl" in encoder_name: implemented_codec = "jpegxl"
                             elif "heic" in encoder_name or "hevc_image" in encoder_name: implemented_codec = "heic"
                             elif "aac" in encoder_name: implemented_codec = "aac"
-                            elif "mp3" in encoder_name: implemented_codec = "mp3lame"
+                            elif "mp3" in encoder_name: implemented_codec = "mp3" # Use "mp3" to match available_codecs
 
                         encoders.append({
                             "name": encoder_name,
@@ -57,6 +57,10 @@ class FFmpegHelpers:
                     {"name": "libmp3lame", "description": "MP3 (MPEG audio layer 3)", "codec": "mp3"},
                     {"name": "flac", "description": "FLAC (Free Lossless Audio Codec)", "codec": "flac"},
                     {"name": "opus", "description": "Opus", "codec": "opus"},
+                    {"name": "libvorbis", "description": "Vorbis", "codec": "vorbis"},
+                    {"name": "pcm_s16le", "description": "PCM signed 16-bit little-endian", "codec": "pcm_s16le"},
+                    {"name": "pcm_alaw", "description": "PCM A-law", "codec": "pcm_alaw"},
+                    {"name": "pcm_mulaw", "description": "PCM mu-law", "codec": "pcm_mulaw"},
                     # Image
                     {"name": "libwebp", "description": "WebP", "codec": "webp"},
                     {"name": "png", "description": "PNG (Portable Network Graphics) image", "codec": "png"},

--- a/ffmpeg-easy-distributed/ffmpeg-gui/gui/main_window.py
+++ b/ffmpeg-easy-distributed/ffmpeg-gui/gui/main_window.py
@@ -2542,18 +2542,27 @@ class MainWindow:
         if not compatible_local:
             fallback_encoders = {
                 'webp': 'libwebp - WebP encoder',
-                'jpegxl': 'libjxl - JPEG XL encoder', 
+                'jpegxl': 'libjxl - JPEG XL encoder',
                 'heic': 'libx265 - HEIC encoder', # Typically uses HEVC encoders
                 'avif': 'libaom-av1 - AVIF encoder', # Typically uses AV1 encoders
                 'png': 'png - PNG encoder',
-                'jpeg': 'mjpeg - Motion JPEG encoder', # or libjpeg
+                'jpeg': 'mjpeg - Motion JPEG encoder', # or libjpeg-turbo
                 'h264': 'libx264 - H.264 encoder',
                 'hevc': 'libx265 - H.265/HEVC encoder',
+                'av1': 'libaom-av1 - AV1 encoder', # Added AV1
+                'vp9': 'libvpx-vp9 - VP9 encoder', # Added VP9
+
+                # Audio codecs - ensure keys match output of FFmpegHelpers.available_codecs()
                 'aac': 'aac - AAC encoder',
+                'mp3': 'libmp3lame - MP3 encoder', # Key is "mp3"
                 'flac': 'flac - FLAC encoder',
-                'mp3': 'libmp3lame - MP3 encoder',
                 'opus': 'libopus - Opus encoder',
-                # Add other common fallbacks as needed
+                'vorbis': 'libvorbis - Vorbis encoder', # Added Vorbis
+                'pcm_s16le': 'pcm_s16le - PCM S16LE encoder', # For WAV
+                'alac': 'alac - ALAC (Apple Lossless Audio Codec) encoder', # Added ALAC
+                'pcm_alaw': 'pcm_alaw - PCM A-law encoder',
+                'pcm_mulaw': 'pcm_mulaw - PCM mu-law encoder',
+                # Add more common PCM formats if necessary
             }
             if codec_to_use in fallback_encoders:
                 compatible_local = [fallback_encoders[codec_to_use]]


### PR DESCRIPTION
Addresses an issue where the encoder dropdown could appear empty for certain audio codecs, especially if `ffmpeg -encoders` fails or provides unexpected output.

Changes:
- Made the parsed `codec` for `libmp3lame` in `FFmpegHelpers` consistently `mp3` to align with `available_codecs`.
- Expanded the hardcoded list of encoders in `FFmpegHelpers` to include more common audio encoders (vorbis, pcm variants).
- Expanded the `fallback_encoders` map in `MainWindow` to cover a wider range of audio codecs (vorbis, pcm, alac), ensuring an option is shown even if primary methods don't find a match.

These changes increase the reliability of encoder selection for audio types.