### PR TITLE
Fix: Further improve audio encoder detection and fallback

### DIFF
--- a/ffmpeg-easy-distributed/ffmpeg-gui/core/ffmpeg_helpers.py
+++ b/ffmpeg-easy-distributed/ffmpeg-gui/core/ffmpeg_helpers.py
@@ -36,6 +36,11 @@ class FFmpegHelpers:
                             elif "heic" in encoder_name or "hevc_image" in encoder_name: implemented_codec = "heic"
                             elif "aac" in encoder_name: implemented_codec = "aac"
                             elif "mp3" in encoder_name: implemented_codec = "mp3" # Use "mp3" to match available_codecs
+                            elif "flac" == encoder_name: implemented_codec = "flac"
+                            elif "alac" == encoder_name: implemented_codec = "alac"
+                            elif "pcm_s16le" == encoder_name: implemented_codec = "pcm_s16le"
+                            elif "opus" in encoder_name: implemented_codec = "opus" # e.g. libopus
+                            elif "vorbis" in encoder_name: implemented_codec = "vorbis" # e.g. libvorbis
 
                         encoders.append({
                             "name": encoder_name,


### PR DESCRIPTION
This commit enhances the robustness of audio encoder population by:

1.  In `FFmpegHelpers.py`:
    *   Adding more specific fallbacks to determine the `implemented_codec`
        for common audio encoders (flac, alac, pcm_s16le, opus, vorbis)
        if their `ffmpeg -encoders` description lacks the `(codec ...)` string.
        This ensures these encoders are correctly typed internally.

2.  Previous changes already included:
    *   Ensuring the `codec` for `libmp3lame` is consistently 'mp3'.
    *   Expanding the hardcoded encoder list in `FFmpegHelpers` for when
        `ffmpeg -encoders` fails.
    *   Expanding the `fallback_encoders` map in `MainWindow` for broader
        coverage.

These changes collectively increase the reliability of finding and displaying appropriate encoders when an audio codec is selected, addressing cases where the encoder list might have appeared empty.